### PR TITLE
Add CCProxy to Tools and Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [How to Use This Repository](#how-to-use-this-repository)
 - [Commands](#commands)
 - [Files](#files)
+- [Tools and Integrations](#tools-and-integrations)
 - [Workflows](#workflows)
 - [Contributing](#contributing)
 - [License](#license)
@@ -90,6 +91,12 @@ This repository includes various files that enhance your experience with Claude 
 
 - **config.yaml**: Basic configuration settings for Claude.
 - **sample_code.py**: A Python script demonstrating how to use Claude for generating code.
+
+## Tools and Integrations
+
+Enhance your Claude Code experience with these powerful tools and integrations:
+
+- [**CCProxy**](https://github.com/orchestre-dev/ccproxy): Use any AI model with Claude Code - OpenAI, Gemini, Groq, OpenRouter and local models via Ollama. Universal API translation proxy with intelligent routing and streaming support.
 
 ## Workflows
 


### PR DESCRIPTION
## Description

This PR adds CCProxy to a new Tools and Integrations section in the awesome-claude-code list.

## What is CCProxy?

CCProxy is a universal API translation proxy that enables Claude Code to work with any AI model - from cloud providers like OpenAI, Gemini, Groq, OpenRouter to local models via Ollama.

## Changes Made

1. Added a new "Tools and Integrations" section to better organize the repository
2. Added CCProxy entry with description highlighting its key features
3. Updated the Table of Contents to include the new section

## Why Include CCProxy?

- **Universal Model Support**: Enables Claude Code users to work with any AI model
- **Local Model Integration**: Unique support for running local models via Ollama
- **Active Development**: Regular updates and community support
- **Open Source**: MIT licensed and free to use

This addition enhances the repository by providing users with a powerful tool to extend Claude Code's capabilities beyond just Anthropic's models.

Thank you for maintaining this resource\!